### PR TITLE
chore: release v0.1.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(deps)"
   
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "dev"
+    commit-message:
+      prefix: "ci(deps)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158d2a98bf4040cf19d3116a2bae7b8093558dab7274f4196680a65194b97b40"
+checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,9 +1006,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3.3"
 strum = "0.24.1"
 strum_macros = "0.24.3"
-signal-hook = "0.3.14"
+signal-hook = "0.3.15"
 clap = { version= "4.0", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ signal-hook = "0.3.14"
 clap = { version= "4.0", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
-error-stack = "0.3.0"
+error-stack = "0.3.1"
 #fasteval = "0.2.4"
 #evalexpr = "8.1.0"
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -7,10 +7,10 @@ use crate::state::{Mode, State};
 pub fn get(state: State) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     trace!("building routes");
     static_routes()
-        .with(log("access-log"))
         .or(mode_routes(state.clone()))
         .or(component_routes(state.clone()))
         .or(plain_routes(state))
+        .with(log("access-log"))
 }
 
 fn with_state(state: State) -> impl Filter<Extract = (State,), Error = Infallible> + Clone {


### PR DESCRIPTION
# 0.1.3

## Bugfixes

- Output correct status code in access log ([#48](https://github.com/fgardt/lighting-manager/pull/48))

## Bump dependencies

- Bump `error-stack` from `0.3.0` to `0.3.1` ([#50](https://github.com/fgardt/lighting-manager/pull/49))
- Bump `signal-hook` from `0.3.14` to `0.3.15` ([#50](https://github.com/fgardt/lighting-manager/pull/50))

## CI

- Configure dependabot to use conventional commits ([#52](https://github.com/fgardt/lighting-manager/pull/52))
